### PR TITLE
fix: update README and package.json for clarity and versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-## Playwright MCP
+## **Fast** Playwright MCP
+
+This MCP server is a fork of the Microsoft one.
+<https://github.com/microsoft/playwright-mcp>
 
 A Model Context Protocol (MCP) server that provides browser automation capabilities using [Playwright](https://playwright.dev). This server enables LLMs to interact with web pages through structured accessibility snapshots, bypassing the need for screenshots or visually-tuned models.
 
@@ -15,10 +18,6 @@ A Model Context Protocol (MCP) server that provides browser automation capabilit
   - `includeSnapshot: false` - Skip page snapshot for minimal responses (70-80% token reduction)
   - `includeConsole: false` - Exclude console messages
   - `includeTabs: false` - Hide tab information
-- **Ultra-Compact Tool Descriptions**. One-line tool descriptions with full parameter details:
-  - 70-80% reduction in tool description tokens
-  - All expectation parameters inline without formatting overhead
-  - Smart tips for efficient usage (e.g., "Use selector to focus on specific area")
 - **Image Compression**. Screenshot tool supports `imageOptions`:
   - `format: 'jpeg'` - Use JPEG instead of PNG
   - `quality: 1-100` - Compress images (e.g., 50 for 50% quality)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tontoko/fast-playwright-mcp",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "publishConfig": {
     "access": "public"
   },
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/tontoko/fast-playwright-mcp"
   },
-  "homepage": "https://playwright.dev",
+  "homepage": "https://github.com/tontoko/fast-playwright-mcp",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
This pull request updates the project to clarify its identity as a fork of Microsoft's Playwright MCP, improves project documentation, and bumps the package version to reflect recent changes.

Project branding and documentation:

* Updated the project name to "**Fast** Playwright MCP" in `README.md` and clarified that this is a fork of Microsoft's Playwright MCP, including a link to the original repository.
* Removed the "Ultra-Compact Tool Descriptions" feature description from the `README.md` to better reflect the current feature set.

Package metadata updates:

* Bumped the package version from `0.0.9` to `0.1.0` in `package.json` to indicate a new release with significant changes.
* Updated the `homepage` field in `package.json` to point to the correct GitHub repository for this fork.