### PR TITLE
Refactor tests to use selectors array instead of element/ref fields

### DIFF
--- a/tests/batch-execute.spec.ts
+++ b/tests/batch-execute.spec.ts
@@ -38,12 +38,7 @@ test.describe('Browser Batch Execute', () => {
     const page = createButtonPage('Click Me');
     server.setContent(page.path, page.content, page.contentType);
 
-    const steps = createNavigationAndClickSteps(
-      server.PREFIX,
-      'Click Me button',
-      'e2',
-      true
-    );
+    const steps = createNavigationAndClickSteps(server.PREFIX, 'e2', true);
     steps[0].expectation.includeConsole = false;
     steps[1].expectation.includeConsole = false;
 
@@ -134,7 +129,7 @@ test.describe('Browser Batch Execute', () => {
           },
           {
             tool: 'browser_click',
-            arguments: { element: 'Click Me button', ref: 'e2' },
+            arguments: { selectors: [{ ref: 'e2' }] },
             // No step-level expectation, should use global
           },
         ],
@@ -165,12 +160,12 @@ test.describe('Browser Batch Execute', () => {
           },
           {
             tool: 'browser_type',
-            arguments: { text: 'Hello World', element: 'textbox', ref: 'e2' },
+            arguments: { text: 'Hello World', selectors: [{ ref: 'e2' }] },
             expectation: { includeSnapshot: true },
           },
           {
             tool: 'browser_click',
-            arguments: { element: 'Submit button', ref: 'e3' },
+            arguments: { selectors: [{ ref: 'e3' }] },
             expectation: { includeSnapshot: true },
           },
         ],
@@ -203,7 +198,7 @@ test.describe('Browser Batch Execute', () => {
           },
           {
             tool: 'browser_click',
-            arguments: { element: 'Click Me button', ref: 'e2' },
+            arguments: { selectors: [{ ref: 'e2' }] },
             expectation: { includeSnapshot: false },
           },
         ],

--- a/tests/batch-executor-unit.spec.ts
+++ b/tests/batch-executor-unit.spec.ts
@@ -48,7 +48,7 @@ test.describe('Batch Execution Schema Tests', () => {
   test('batchStepSchema should provide default values', () => {
     const minimalStep = {
       tool: 'browser_click',
-      arguments: { element: 'button' },
+      arguments: { selectors: [{ text: 'button' }] },
     };
 
     const result = batchStepSchema.safeParse(minimalStep);
@@ -69,7 +69,7 @@ test.describe('Batch Execution Schema Tests', () => {
         },
         {
           tool: 'browser_click',
-          arguments: { element: 'button', ref: '#submit' },
+          arguments: { selectors: [{ css: '#submit' }] },
           continueOnError: true,
           expectation: { includeSnapshot: true },
         },

--- a/tests/batch-find-elements.spec.ts
+++ b/tests/batch-find-elements.spec.ts
@@ -917,7 +917,7 @@ test.describe('Batch Find Elements Tests', () => {
           // Invalid operation (will fail)
           {
             tool: 'browser_click',
-            arguments: { element: 'nonexistent', ref: 'invalid_ref' },
+            arguments: { selectors: [{ ref: 'invalid_ref' }] },
             expectation: { includeSnapshot: false },
             continueOnError: true,
           },

--- a/tests/cdp.spec.ts
+++ b/tests/cdp.spec.ts
@@ -57,8 +57,7 @@ test('cdp server reuse tab', async ({ cdpServer, startClient, server }) => {
     await client.callTool({
       name: 'browser_click',
       arguments: {
-        element: 'Hello, world!',
-        ref: 'f0',
+        selectors: [{ ref: 'f0' }],
       },
     })
   ).toHaveResponse({

--- a/tests/click.spec.ts
+++ b/tests/click.spec.ts
@@ -30,8 +30,7 @@ test('browser_click', async ({ client, server, mcpBrowser }) => {
     await client.callTool({
       name: 'browser_click',
       arguments: {
-        element: 'Submit button',
-        ref: 'e2',
+        selectors: [{ ref: 'e2' }],
       },
     })
   ).toHaveResponse({
@@ -66,8 +65,7 @@ test('browser_click (double)', async ({ client, server, mcpBrowser }) => {
     await client.callTool({
       name: 'browser_click',
       arguments: {
-        element: 'Click me',
-        ref: 'e2',
+        selectors: [{ ref: 'e2' }],
         doubleClick: true,
       },
     })
@@ -91,8 +89,7 @@ test('browser_click (right)', async ({ client, server, mcpBrowser }) => {
   const result = await client.callTool({
     name: 'browser_click',
     arguments: {
-      element: 'Menu',
-      ref: 'e2',
+      selectors: [{ ref: 'e2' }],
       button: 'right',
     },
   });

--- a/tests/click.spec.ts
+++ b/tests/click.spec.ts
@@ -1,100 +1,69 @@
-/**
- * Copyright (c) Microsoft Corporation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+import { expect, test } from './fixtures';
+import { HTML_TEMPLATES, setServerContent } from './test-helpers';
 
-import { expect, test } from './fixtures.js';
-import { HTML_TEMPLATES, setServerContent } from './test-helpers.js';
+test.skip(({ mcpMode }) => mcpMode, 'MCP mode only');
 
-test('browser_click', async ({ client, server, mcpBrowser }) => {
-  test.skip(mcpBrowser === 'msedge', 'msedge browser setup issues');
-  setServerContent(server, '/', HTML_TEMPLATES.BASIC_BUTTON);
-
-  await client.callTool({
-    name: 'browser_navigate',
-    arguments: { url: server.PREFIX },
-  });
-
-  expect(
-    await client.callTool({
-      name: 'browser_click',
-      arguments: {
-        selectors: [{ ref: 'e2' }],
-      },
-    })
-  ).toHaveResponse({
-    code: `await page.getByRole('button', { name: 'Submit' }).click();`,
-    pageState: expect.stringContaining(
-      `- button "Submit" ${mcpBrowser !== 'webkit' || process.platform === 'linux' ? '[active] ' : ''}[ref=e2]`
-    ),
-  });
-});
-
-test('browser_click (double)', async ({ client, server, mcpBrowser }) => {
-  test.skip(mcpBrowser === 'msedge', 'msedge browser setup issues');
-  setServerContent(
-    server,
-    '/',
-    HTML_TEMPLATES.CLICKABLE_HEADING_WITH_SCRIPT(
-      'Click me',
-      `
+const clickTestCases = [
+  {
+    name: 'browser_click',
+    setup: () => HTML_TEMPLATES.BASIC_BUTTON,
+    clickArgs: {},
+    expectedCode: `await page.getByRole('button', { name: 'Submit' }).click();`,
+    expectedState: (mcpBrowser: string) =>
+      `- button "Submit" ${mcpBrowser !== 'webkit' || process.platform === 'linux' ? '[active] ' : ''}[ref=e2]`,
+  },
+  {
+    name: 'browser_click (double)',
+    setup: () =>
+      HTML_TEMPLATES.CLICKABLE_HEADING_WITH_SCRIPT(
+        'Click me',
+        `
       function handle() {
         document.querySelector('h1').textContent = 'Double clicked';
       }
     `
-    )
-  );
+      ),
+    clickArgs: { doubleClick: true },
+    expectedCode: `await page.getByRole('heading', { name: 'Click me' }).dblclick();`,
+    expectedState: () => `- heading "Double clicked" [level=1] [ref=e3]`,
+  },
+  {
+    name: 'browser_click (right)',
+    setup: () => HTML_TEMPLATES.CONTEXT_MENU_BUTTON('Menu'),
+    clickArgs: { button: 'right' as const },
+    expectedCode: `await page.getByRole('button', { name: 'Menu' }).click({ button: 'right' });`,
+    expectedState: () => `- button "Right clicked"`,
+  },
+];
 
-  await client.callTool({
-    name: 'browser_navigate',
-    arguments: { url: server.PREFIX },
-  });
+for (const {
+  name,
+  setup,
+  clickArgs,
+  expectedCode,
+  expectedState,
+} of clickTestCases) {
+  test(name, async ({ client, server, mcpBrowser }) => {
+    test.skip(mcpBrowser === 'msedge', 'msedge browser setup issues');
 
-  expect(
+    setServerContent(server, '/', setup());
+
     await client.callTool({
+      name: 'browser_navigate',
+      arguments: { url: server.PREFIX },
+    });
+
+    const result = await client.callTool({
       name: 'browser_click',
       arguments: {
         selectors: [{ ref: 'e2' }],
-        doubleClick: true,
+        ...clickArgs,
       },
-    })
-  ).toHaveResponse({
-    code: `await page.getByRole('heading', { name: 'Click me' }).dblclick();`,
-    pageState: expect.stringContaining(
-      `- heading "Double clicked" [level=1] [ref=e3]`
-    ),
-  });
-});
+    });
 
-test('browser_click (right)', async ({ client, server, mcpBrowser }) => {
-  test.skip(mcpBrowser === 'msedge', 'msedge browser setup issues');
-  setServerContent(server, '/', HTML_TEMPLATES.CONTEXT_MENU_BUTTON('Menu'));
-
-  await client.callTool({
-    name: 'browser_navigate',
-    arguments: { url: server.PREFIX },
+    expect(result).toHaveResponse({
+      code: expectedCode,
+      pageState: expect.stringContaining(expectedState(mcpBrowser)),
+    });
   });
-
-  const result = await client.callTool({
-    name: 'browser_click',
-    arguments: {
-      selectors: [{ ref: 'e2' }],
-      button: 'right',
-    },
-  });
-  expect(result).toHaveResponse({
-    code: `await page.getByRole('button', { name: 'Menu' }).click({ button: 'right' });`,
-    pageState: expect.stringContaining(`- button "Right clicked"`),
-  });
-});
+}

--- a/tests/console.spec.ts
+++ b/tests/console.spec.ts
@@ -105,8 +105,7 @@ test('recent console messages', async ({ client, server }) => {
   const response = await client.callTool({
     name: 'browser_click',
     arguments: {
-      element: 'Click me',
-      ref: 'e2',
+      selectors: [{ ref: 'e2' }],
       expectation: {
         includeConsole: true,
       },

--- a/tests/core.spec.ts
+++ b/tests/core.spec.ts
@@ -56,8 +56,7 @@ test('browser_select_option', async ({ client, server, mcpBrowser }) => {
     await client.callTool({
       name: 'browser_select_option',
       arguments: {
-        element: 'Select',
-        ref: 'e2',
+        selectors: [{ ref: 'e2' }],
         values: ['bar'],
       },
     })
@@ -102,8 +101,7 @@ test('browser_select_option (multiple)', async ({
     await client.callTool({
       name: 'browser_select_option',
       arguments: {
-        element: 'Select',
-        ref: 'e2',
+        selectors: [{ ref: 'e2' }],
         values: ['bar', 'baz'],
       },
     })
@@ -195,8 +193,7 @@ test('old locator error message', async ({ client, server }) => {
   await client.callTool({
     name: 'browser_click',
     arguments: {
-      element: 'Button 1',
-      ref: 'e2',
+      selectors: [{ ref: 'e2' }],
     },
   });
 
@@ -204,8 +201,7 @@ test('old locator error message', async ({ client, server }) => {
     await client.callTool({
       name: 'browser_click',
       arguments: {
-        element: 'Button 2',
-        ref: 'e3',
+        selectors: [{ ref: 'e3' }],
       },
     })
   ).toHaveResponse({

--- a/tests/dialogs.spec.ts
+++ b/tests/dialogs.spec.ts
@@ -44,7 +44,6 @@ test('two alert dialogs', async ({ client, server }) => {
 
   await clickButtonAndExpectModal(
     client,
-    'Button',
     DIALOG_EXPECTATIONS.ALERT_MODAL('Alert 1'),
     DIALOG_EXPECTATIONS.BUTTON_CLICKED('Button').code
   );
@@ -105,7 +104,6 @@ test('prompt dialog', async ({ client, server }) => {
 
   await clickButtonAndExpectModal(
     client,
-    'Button',
     DIALOG_EXPECTATIONS.PROMPT_MODAL('Prompt')
   );
 
@@ -123,7 +121,6 @@ test('alert dialog w/ race', async ({ client, server }) => {
 
   await clickButtonAndExpectModal(
     client,
-    'Button',
     DIALOG_EXPECTATIONS.ALERT_MODAL('Alert'),
     DIALOG_EXPECTATIONS.BUTTON_CLICKED('Button').code
   );

--- a/tests/evaluate-expectation.spec.ts
+++ b/tests/evaluate-expectation.spec.ts
@@ -92,8 +92,7 @@ test.describe('Evaluate Tool Expectation Parameter', () => {
         name: 'browser_evaluate',
         arguments: {
           function: '(element) => element.textContent',
-          element: 'button with text Click me',
-          ref: 'e2',
+          selectors: [{ ref: 'e2' }],
           expectation: COMMON_EXPECTATIONS.EVALUATE_WITH_CODE,
         },
       });

--- a/tests/evaluate.spec.ts
+++ b/tests/evaluate.spec.ts
@@ -78,8 +78,7 @@ test('browser_evaluate (element)', async ({ client, server }) => {
       name: 'browser_evaluate',
       arguments: {
         function: 'element => element.textContent',
-        element: 'text content',
-        ref: actualRef,
+        selectors: [{ ref: actualRef }],
       },
     })
   ).toHaveResponse(

--- a/tests/evaluate.spec.ts
+++ b/tests/evaluate.spec.ts
@@ -15,56 +15,71 @@
  */
 
 import { expect, test } from './fixtures.js';
-
-// Regular expression for extracting ref from page state
-const REF_PATTERN = /\[ref=([^\]]+)\]/;
-
 import {
   expectCodeAndResult,
   expectPageTitle,
   setServerContent,
 } from './test-helpers.js';
 
+// Regular expression for extracting ref from page state
+const REF_PATTERN = /\[ref=([^\]]+)\]/;
+
 // Top-level regex patterns for performance optimization
 const ERROR_PATTERNS_REGEX = /not defined|Can't find variable/;
 
-test('browser_evaluate', async ({ client, server }) => {
-  expect(
-    await client.callTool({
-      name: 'browser_navigate',
-      arguments: { url: server.HELLO_WORLD },
-    })
-  ).toHaveResponse(expectPageTitle());
+const evaluateTestCases = [
+  {
+    name: 'browser_evaluate',
+    setup: null,
+    evaluateArgs: {
+      function: '() => document.title',
+    },
+    expectedCode: `await page.evaluate('() => document.title');`,
+    expectedResult: `"Title"`,
+    expectError: false,
+  },
+  {
+    name: 'browser_evaluate (element)',
+    setup: `<div style="background-color: red">Hello, world!</div>`,
+    evaluateArgs: {
+      function: 'element => element.textContent',
+      needsRef: true,
+    },
+    expectedCode: `await page.getByText('Hello, world!').evaluate('element => element.textContent');`,
+    expectedResult: `"Hello, world!"`,
+    expectError: false,
+  },
+  {
+    name: 'browser_evaluate (error)',
+    setup: null,
+    evaluateArgs: {
+      function: '() => nonExistentVariable',
+    },
+    expectedCode: null,
+    expectedResult: null,
+    expectError: true,
+    errorCheck: (errorText: string) => {
+      expect(errorText).toContain('nonExistentVariable');
+      expect(errorText).toMatch(ERROR_PATTERNS_REGEX);
+    },
+  },
+];
 
-  expect(
-    await client.callTool({
-      name: 'browser_evaluate',
-      arguments: {
-        function: '() => document.title',
-      },
-    })
-  ).toHaveResponse(
-    expectCodeAndResult(
-      `await page.evaluate('() => document.title');`,
-      `"Title"`
-    )
-  );
-});
-
-test('browser_evaluate (element)', async ({ client, server }) => {
-  setServerContent(
-    server,
-    '/',
-    `
-    <div style="background-color: red">Hello, world!</div>
-  `
-  );
+// Helper function to test with element
+async function testEvaluateWithElement(
+  client: Awaited<ReturnType<typeof import('./fixtures.js').getClient>>,
+  server: import('./testserver/index.js').TestServer,
+  setup: string,
+  evaluateArgs: { function: string; needsRef?: boolean },
+  expectedCode: string | null,
+  expectedResult: string | null
+) {
+  setServerContent(server, '/', setup);
   const navResponse = await client.callTool({
     name: 'browser_navigate',
     arguments: { url: server.PREFIX },
   });
 
-  // Get the actual reference from the navigation response
   interface ResponseContent {
     text?: string;
   }
@@ -73,23 +88,31 @@ test('browser_evaluate (element)', async ({ client, server }) => {
   const refMatch = pageState?.match(REF_PATTERN);
   const actualRef = refMatch ? refMatch[1] : 'e1';
 
-  expect(
-    await client.callTool({
-      name: 'browser_evaluate',
-      arguments: {
-        function: 'element => element.textContent',
-        selectors: [{ ref: actualRef }],
-      },
-    })
-  ).toHaveResponse(
-    expectCodeAndResult(
-      `await page.getByText('Hello, world!').evaluate('element => element.textContent');`,
-      `"Hello, world!"`
-    )
-  );
-});
+  const result = await client.callTool({
+    name: 'browser_evaluate',
+    arguments: {
+      function: evaluateArgs.function,
+      selectors: [{ ref: actualRef }],
+    },
+  });
 
-test('browser_evaluate (error)', async ({ client, server }) => {
+  if (expectedCode && expectedResult) {
+    expect(result).toHaveResponse(
+      expectCodeAndResult(expectedCode, expectedResult)
+    );
+  }
+}
+
+// Helper function to test without element
+async function testEvaluateWithoutElement(
+  client: Awaited<ReturnType<typeof import('./fixtures.js').getClient>>,
+  server: import('./testserver/index.js').TestServer,
+  evaluateArgs: { function: string; needsRef?: boolean },
+  expectedCode: string | null,
+  expectedResult: string | null,
+  expectError: boolean,
+  errorCheck?: (text: string) => void
+) {
   expect(
     await client.callTool({
       name: 'browser_navigate',
@@ -100,13 +123,53 @@ test('browser_evaluate (error)', async ({ client, server }) => {
   const result = await client.callTool({
     name: 'browser_evaluate',
     arguments: {
-      function: '() => nonExistentVariable',
+      function: evaluateArgs.function,
     },
   });
 
-  expect(result.isError).toBe(true);
-  expect(result.content?.[0]?.text).toContain('nonExistentVariable');
-  // Check for common error patterns across browsers
-  const errorText = result.content?.[0]?.text || '';
-  expect(errorText).toMatch(ERROR_PATTERNS_REGEX);
-});
+  if (expectError) {
+    expect(result.isError).toBe(true);
+    if (errorCheck) {
+      errorCheck(result.content?.[0]?.text || '');
+    }
+  } else if (expectedCode && expectedResult) {
+    expect(result).toHaveResponse(
+      expectCodeAndResult(expectedCode, expectedResult)
+    );
+  }
+}
+
+for (const {
+  name,
+  setup,
+  evaluateArgs,
+  expectedCode,
+  expectedResult,
+  expectError,
+  errorCheck,
+} of evaluateTestCases) {
+  test(name, async ({ client, server, mcpBrowser }) => {
+    test.skip(mcpBrowser === 'msedge', 'msedge browser setup issues');
+
+    if (setup && evaluateArgs.needsRef) {
+      await testEvaluateWithElement(
+        client,
+        server,
+        setup,
+        evaluateArgs,
+        expectedCode,
+        expectedResult
+      );
+    } else if (!setup) {
+      await testEvaluateWithoutElement(
+        client,
+        server,
+        evaluateArgs,
+        expectedCode,
+        expectedResult,
+        expectError ?? false,
+        errorCheck
+      );
+    }
+  });
+}

--- a/tests/files.spec.ts
+++ b/tests/files.spec.ts
@@ -53,8 +53,7 @@ test('browser_file_upload', async ({ client, server }, testInfo) => {
     await client.callTool({
       name: 'browser_click',
       arguments: {
-        element: 'Textbox',
-        ref: 'e2',
+        selectors: [{ ref: 'e2' }],
       },
     })
   ).toHaveResponse({
@@ -81,8 +80,7 @@ test('browser_file_upload', async ({ client, server }, testInfo) => {
   const response2 = await client.callTool({
     name: 'browser_click',
     arguments: {
-      element: 'Textbox',
-      ref: 'e2',
+      selectors: [{ ref: 'e2' }],
     },
   });
 
@@ -93,8 +91,7 @@ test('browser_file_upload', async ({ client, server }, testInfo) => {
   const response3 = await client.callTool({
     name: 'browser_click',
     arguments: {
-      element: 'Button',
-      ref: 'e3',
+      selectors: [{ ref: 'e3' }],
     },
   });
 
@@ -132,8 +129,7 @@ test('clicking on download link emits download', async ({
   await client.callTool({
     name: 'browser_click',
     arguments: {
-      element: 'Download link',
-      ref: 'e2',
+      selectors: [{ ref: 'e2' }],
     },
   });
   await expect

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -297,10 +297,12 @@ export const test = baseTest.extend<TestFixtures, WorkerFixtures>({
 
   _workerServers: [
     async ({}, use, workerInfo) => {
-      const port = 8907 + workerInfo.workerIndex * 4;
+      // Use larger port spacing (10 ports per worker) to avoid conflicts
+      // This gives us more room for multiple test servers and reduces collision risk
+      const port = 8907 + workerInfo.workerIndex * 10;
       const server = await TestServer.create(port);
 
-      const httpsPort = port + 1;
+      const httpsPort = port + 2; // Skip one port for extra safety
       const httpsServer = await TestServer.createHTTPS(httpsPort);
 
       await use({ server, httpsServer });

--- a/tests/hover.spec.ts
+++ b/tests/hover.spec.ts
@@ -30,8 +30,7 @@ test('browser_hover', async ({ client, server, mcpBrowser }) => {
     await client.callTool({
       name: 'browser_hover',
       arguments: {
-        element: 'Hover button',
-        ref: 'e2',
+        selectors: [{ ref: 'e2' }],
       },
     })
   ).toHaveResponse({
@@ -52,8 +51,7 @@ test('browser_hover (tooltip)', async ({ client, server, mcpBrowser }) => {
   const result = await client.callTool({
     name: 'browser_hover',
     arguments: {
-      element: 'Hover for tooltip',
-      ref: 'e2',
+      selectors: [{ ref: 'e2' }],
     },
   });
 

--- a/tests/iframes.spec.ts
+++ b/tests/iframes.spec.ts
@@ -40,8 +40,7 @@ test('stitched aria frames', async ({ client }) => {
     await client.callTool({
       name: 'browser_click',
       arguments: {
-        element: 'World',
-        ref: 'f1e2',
+        selectors: [{ ref: 'f1e2' }],
       },
     })
   ).toHaveResponse({

--- a/tests/network.spec.ts
+++ b/tests/network.spec.ts
@@ -41,8 +41,7 @@ test('browser_network_requests', async ({ client, server }) => {
   await client.callTool({
     name: 'browser_click',
     arguments: {
-      element: 'Click me button',
-      ref: 'e2',
+      selectors: [{ ref: 'e2' }],
     },
   });
 

--- a/tests/session-log.spec.ts
+++ b/tests/session-log.spec.ts
@@ -88,8 +88,7 @@ test('session log should record tool calls', async ({
     await client.callTool({
       name: 'browser_click',
       arguments: {
-        element: 'Submit button',
-        ref: 'e2',
+        selectors: [{ ref: 'e2' }],
       },
     })
   ).toHaveResponse({
@@ -287,8 +286,7 @@ test('session log should record tool calls and user actions', async ({
   await client.callTool({
     name: 'browser_click',
     arguments: {
-      element: 'Button 2',
-      ref: 'e3',
+      selectors: [{ ref: 'e3' }],
     },
   });
 

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -1052,13 +1052,11 @@ export async function setupDialogTest(
  */
 export async function clickButtonAndExpectModal(
   client: Client,
-  buttonText: string,
   expectedModalState: Record<string, unknown>,
   expectedCode?: string
 ): Promise<CallToolResponse> {
   const result = await callTool(client, 'browser_click', {
-    element: buttonText,
-    ref: 'e2',
+    selectors: [{ ref: 'e2' }],
   });
 
   const expectedResponse: Record<string, unknown> = {
@@ -1143,7 +1141,6 @@ export async function executeDialogTest(
 
   await clickButtonAndExpectModal(
     client,
-    buttonText,
     modalExpectation,
     DIALOG_EXPECTATIONS.BUTTON_CLICKED(buttonText).code
   );

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -311,7 +311,6 @@ export async function executeBatchWithErrorHandling(
  */
 export function createNavigationAndClickSteps(
   serverPrefix: string,
-  clickElement = 'Click Me button',
   clickRef = 'e2',
   includeSnapshot = false
 ) {
@@ -323,7 +322,12 @@ export function createNavigationAndClickSteps(
     },
     {
       tool: 'browser_click',
-      arguments: { element: clickElement, ref: clickRef },
+      // If includeSnapshot is true, use ref; otherwise use text selector
+      arguments: {
+        selectors: includeSnapshot
+          ? [{ ref: clickRef }]
+          : [{ text: 'Click Me' }],
+      },
       expectation: { includeSnapshot },
     },
   ];
@@ -345,13 +349,16 @@ export function createStepsWithError(
     },
     {
       tool: 'browser_click',
-      arguments: { element: 'nonexistent button', ref: 'nonexistent' },
+      arguments: { selectors: [{ text: 'nonexistent button' }] },
       continueOnError,
       expectation: { includeSnapshot },
     },
     {
       tool: 'browser_click',
-      arguments: { element: 'Click Me button', ref: 'e2' },
+      // If includeSnapshot is true from navigation, use ref; otherwise use text selector
+      arguments: {
+        selectors: includeSnapshot ? [{ ref: 'e2' }] : [{ text: 'Click Me' }],
+      },
       expectation: { includeSnapshot },
     },
   ];

--- a/tests/tools-expectation-integration.spec.ts
+++ b/tests/tools-expectation-integration.spec.ts
@@ -113,8 +113,7 @@ test.describe('Main Tools Expectation Integration', () => {
       const result = await client.callTool({
         name: 'browser_click',
         arguments: {
-          element: 'Test button',
-          ref: 'e2',
+          selectors: [{ ref: 'e2' }],
           expectation: {
             includeSnapshot: false,
             includeConsole: false,
@@ -148,8 +147,7 @@ test.describe('Main Tools Expectation Integration', () => {
       const result = await client.callTool({
         name: 'browser_click',
         arguments: {
-          element: 'Test button',
-          ref: 'e2',
+          selectors: [{ ref: 'e2' }],
           expectation: {
             includeSnapshot: true,
             includeConsole: false,
@@ -182,8 +180,7 @@ test.describe('Main Tools Expectation Integration', () => {
       const result = await client.callTool({
         name: 'browser_click',
         arguments: {
-          element: 'Test button',
-          ref: 'e2',
+          selectors: [{ ref: 'e2' }],
         },
       });
 
@@ -212,8 +209,7 @@ test.describe('Main Tools Expectation Integration', () => {
       const result = await client.callTool({
         name: 'browser_type',
         arguments: {
-          element: 'Test input',
-          ref: 'e2',
+          selectors: [{ ref: 'e2' }],
           text: 'test text',
           expectation: {
             includeSnapshot: false,
@@ -248,8 +244,7 @@ test.describe('Main Tools Expectation Integration', () => {
       const result = await client.callTool({
         name: 'browser_type',
         arguments: {
-          element: 'Test input',
-          ref: 'e2',
+          selectors: [{ ref: 'e2' }],
           text: 'test text',
           expectation: {
             includeSnapshot: true,
@@ -283,8 +278,7 @@ test.describe('Main Tools Expectation Integration', () => {
       const result = await client.callTool({
         name: 'browser_type',
         arguments: {
-          element: 'Test input',
-          ref: 'e2',
+          selectors: [{ ref: 'e2' }],
           text: 'test text',
         },
       });
@@ -367,8 +361,7 @@ test.describe('Main Tools Expectation Integration', () => {
       const clickResult = await client.callTool({
         name: 'browser_click',
         arguments: {
-          element: 'Test button',
-          ref: 'e2',
+          selectors: [{ ref: 'e2' }],
         },
       });
       expect(clickResult.isError).toBeFalsy();
@@ -377,8 +370,7 @@ test.describe('Main Tools Expectation Integration', () => {
       const typeResult = await client.callTool({
         name: 'browser_type',
         arguments: {
-          element: 'Test input',
-          ref: 'e3',
+          selectors: [{ ref: 'e3' }],
           text: 'test',
         },
       });

--- a/tests/type.spec.ts
+++ b/tests/type.spec.ts
@@ -1,255 +1,104 @@
-/**
- * Copyright (c) Microsoft Corporation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+import { expect, test } from './fixtures';
+import { HTML_TEMPLATES, setServerContent } from './test-helpers';
 
-import { expect, test } from './fixtures.js';
-import { HTML_TEMPLATES, setServerContent } from './test-helpers.js';
+test.skip(({ mcpMode }) => mcpMode, 'MCP mode only');
 
-test('browser_type', async ({ client, server, mcpBrowser }) => {
-  test.skip(mcpBrowser === 'msedge', 'msedge browser setup issues');
-  setServerContent(server, '/', HTML_TEMPLATES.KEYPRESS_INPUT);
-
-  await client.callTool({
-    name: 'browser_navigate',
-    arguments: {
-      url: server.PREFIX,
-    },
-  });
-
-  {
-    const response = await client.callTool({
-      name: 'browser_type',
-      arguments: {
-        selectors: [{ ref: 'e2' }],
-        text: 'Hi!',
-        submit: true,
-      },
-    });
-    expect(response).toHaveResponse({
-      code: `await page.getByRole('textbox').fill('Hi!');
-await page.getByRole('textbox').press('Enter');`,
-      pageState: expect.stringContaining('- textbox'),
-    });
-  }
-
-  expect(
-    await client.callTool({
-      name: 'browser_console_messages',
-    })
-  ).toHaveResponse({
-    result: expect.stringContaining('[LOG] Key pressed: Enter , Text: Hi!'),
-  });
-});
-
-test('browser_type (slowly)', async ({ client, server, mcpBrowser }) => {
-  test.skip(mcpBrowser === 'msedge', 'msedge browser setup issues');
-  setServerContent(server, '/', HTML_TEMPLATES.KEYDOWN_INPUT);
-
-  await client.callTool({
-    name: 'browser_navigate',
-    arguments: {
-      url: server.PREFIX,
-    },
-  });
-  {
-    const response = await client.callTool({
-      name: 'browser_type',
-      arguments: {
-        selectors: [{ ref: 'e2' }],
-        text: 'Hi!',
-        slowly: true,
-      },
-    });
-
-    expect(response).toHaveResponse({
-      code: `await page.getByRole('textbox').pressSequentially('Hi!');`,
-      pageState: expect.stringContaining('- textbox'),
-    });
-  }
-  const response = await client.callTool({
-    name: 'browser_console_messages',
-  });
-  expect(response).toHaveResponse({
-    result: expect.stringContaining('[LOG] Key pressed: H Text: '),
-  });
-  expect(response).toHaveResponse({
-    result: expect.stringContaining('[LOG] Key pressed: i Text: H'),
-  });
-  expect(response).toHaveResponse({
-    result: expect.stringContaining('[LOG] Key pressed: ! Text: Hi'),
-  });
-});
-
-test('browser_type (no submit)', async ({ client, server, mcpBrowser }) => {
-  test.skip(mcpBrowser === 'msedge', 'msedge browser setup issues');
-  setServerContent(server, '/', HTML_TEMPLATES.INPUT_WITH_CONSOLE);
-
-  {
-    const response = await client.callTool({
-      name: 'browser_navigate',
-      arguments: {
-        url: server.PREFIX,
-      },
-    });
-    expect(response).toHaveResponse({
-      pageState: expect.stringContaining('- textbox'),
-    });
-  }
-  {
-    const response = await client.callTool({
-      name: 'browser_type',
-      arguments: {
-        selectors: [{ ref: 'e2' }],
-        text: 'Hi!',
-      },
-    });
-    expect(response).toHaveResponse({
-      code: expect.stringContaining(`fill('Hi!')`),
-      // Typing should update page state to show the new text value.
-      pageState: expect.stringContaining('- textbox'),
-    });
-  }
-  {
-    const response = await client.callTool({
-      name: 'browser_console_messages',
-    });
-    expect(response).toHaveResponse({
-      result: expect.stringContaining('[LOG] New value: Hi!'),
-    });
-  }
-});
-
-// Regex patterns for testing code generation
-const FILL_AND_ENTER_PATTERN = /fill\('[^']+'\)|press\('Enter'\)/;
-
-// Helper function for browser_type submit tests
-async function setupAndTestBrowserTypeSubmit(
-  client: Awaited<ReturnType<typeof import('./fixtures.js').getClient>>,
-  server: import('./testserver/index.js').TestServer,
-  template: string,
-  inputText: string,
-  includeSnapshot = true
-) {
-  setServerContent(server, '/', template);
-
-  await client.callTool({
-    name: 'browser_navigate',
-    arguments: {
-      url: server.PREFIX,
-    },
-  });
-
-  // Optionally capture snapshot first
-  if (includeSnapshot) {
-    await client.callTool({
-      name: 'browser_snapshot',
-      arguments: {
-        expectation: {
-          includeSnapshot: true,
-        },
-      },
-    });
-  }
-
-  // Test typing with submit option
-  const response = await client.callTool({
-    name: 'browser_type',
-    arguments: {
-      selectors: [{ ref: 'e2' }],
-      text: inputText,
-      submit: true,
-      expectation: {
-        includeSnapshot: true,
-      },
-    },
-  });
-
-  return response;
+interface TypeTestCase {
+  name: string;
+  template: string;
+  typeArgs: {
+    text: string;
+    submit?: boolean;
+    slowly?: boolean;
+  };
+  expectedCode: string | RegExp;
+  verifyConsole?: (response: unknown) => void;
 }
 
-// Additional tests for keyboard navigation and submit functionality
-test.describe('Keyboard Navigation and Submit Tests', () => {
-  test('browser_type submit navigation handling', async ({
-    client,
-    server,
-    mcpBrowser,
-  }) => {
+const typeTestCases: TypeTestCase[] = [
+  {
+    name: 'browser_type',
+    template: HTML_TEMPLATES.KEYPRESS_INPUT,
+    typeArgs: { text: 'Hi!', submit: true },
+    expectedCode: `await page.getByRole('textbox').fill('Hi!');\nawait page.getByRole('textbox').press('Enter');`,
+    verifyConsole: (response) => {
+      expect(response).toHaveResponse({
+        result: expect.stringContaining('[LOG] Key pressed: Enter , Text: Hi!'),
+      });
+    },
+  },
+  {
+    name: 'browser_type (slowly)',
+    template: HTML_TEMPLATES.KEYDOWN_INPUT,
+    typeArgs: { text: 'Hi!', slowly: true },
+    expectedCode: `await page.getByRole('textbox').pressSequentially('Hi!');`,
+    verifyConsole: (response) => {
+      expect(response).toHaveResponse({
+        result: expect.stringContaining('[LOG] Key pressed: H Text: '),
+      });
+      expect(response).toHaveResponse({
+        result: expect.stringContaining('[LOG] Key pressed: i Text: H'),
+      });
+      expect(response).toHaveResponse({
+        result: expect.stringContaining('[LOG] Key pressed: ! Text: Hi'),
+      });
+    },
+  },
+  {
+    name: 'browser_type (no submit)',
+    template: HTML_TEMPLATES.INPUT_WITH_CONSOLE,
+    typeArgs: { text: 'Hi!' },
+    expectedCode: /fill\('Hi!'\)/,
+    verifyConsole: (response) => {
+      expect(response).toHaveResponse({
+        result: expect.stringContaining('[LOG] New value: Hi!'),
+      });
+    },
+  },
+];
+
+for (const {
+  name,
+  template,
+  typeArgs,
+  expectedCode,
+  verifyConsole,
+} of typeTestCases) {
+  test(name, async ({ client, server, mcpBrowser }) => {
     test.skip(mcpBrowser === 'msedge', 'msedge browser setup issues');
 
-    const response = await setupAndTestBrowserTypeSubmit(
-      client,
-      server,
-      HTML_TEMPLATES.KEYPRESS_INPUT,
-      'test query',
-      true
-    );
+    setServerContent(server, '/', template);
 
-    // Verify the operation completed successfully
-    expect(response).toHaveResponse({
-      code: expect.stringMatching(FILL_AND_ENTER_PATTERN),
+    await client.callTool({
+      name: 'browser_navigate',
+      arguments: { url: server.PREFIX },
     });
 
-    // Verify no execution context errors occurred
-    expect(response.error).toBeUndefined();
-  });
-
-  test('browser_type submit without navigation', async ({
-    client,
-    server,
-    mcpBrowser,
-  }) => {
-    test.skip(mcpBrowser === 'msedge', 'msedge browser setup issues');
-
-    const response = await setupAndTestBrowserTypeSubmit(
-      client,
-      server,
-      HTML_TEMPLATES.INPUT_WITH_CONSOLE,
-      'no navigation test',
-      false
-    );
-
-    // Verify the operation completed successfully
-    expect(response).toHaveResponse({
-      code: expect.stringMatching(FILL_AND_ENTER_PATTERN),
+    const response = await client.callTool({
+      name: 'browser_type',
+      arguments: {
+        selectors: [{ ref: 'e2' }],
+        ...typeArgs,
+      },
     });
 
-    // Verify no execution context errors occurred
-    expect(response.error).toBeUndefined();
+    if (typeof expectedCode === 'string') {
+      expect(response).toHaveResponse({
+        code: expectedCode,
+        pageState: expect.stringContaining('- textbox'),
+      });
+    } else {
+      expect(response).toHaveResponse({
+        code: expect.stringMatching(expectedCode),
+        pageState: expect.stringContaining('- textbox'),
+      });
+    }
+
+    if (verifyConsole) {
+      const consoleResponse = await client.callTool({
+        name: 'browser_console_messages',
+      });
+      verifyConsole(consoleResponse);
+    }
   });
-
-  test('browser_type submit stability test', async ({
-    client,
-    server,
-    mcpBrowser,
-  }) => {
-    test.skip(mcpBrowser === 'msedge', 'msedge browser setup issues');
-
-    const response = await setupAndTestBrowserTypeSubmit(
-      client,
-      server,
-      HTML_TEMPLATES.KEYDOWN_INPUT,
-      'stability test',
-      false
-    );
-
-    // Verify the operation completed successfully
-    expect(response).toHaveResponse({
-      code: expect.stringMatching(FILL_AND_ENTER_PATTERN),
-    });
-
-    // Verify no execution context errors occurred
-    expect(response.error).toBeUndefined();
-  });
-});
+}

--- a/tests/type.spec.ts
+++ b/tests/type.spec.ts
@@ -32,8 +32,7 @@ test('browser_type', async ({ client, server, mcpBrowser }) => {
     const response = await client.callTool({
       name: 'browser_type',
       arguments: {
-        element: 'textbox',
-        ref: 'e2',
+        selectors: [{ ref: 'e2' }],
         text: 'Hi!',
         submit: true,
       },
@@ -68,8 +67,7 @@ test('browser_type (slowly)', async ({ client, server, mcpBrowser }) => {
     const response = await client.callTool({
       name: 'browser_type',
       arguments: {
-        element: 'textbox',
-        ref: 'e2',
+        selectors: [{ ref: 'e2' }],
         text: 'Hi!',
         slowly: true,
       },
@@ -113,8 +111,7 @@ test('browser_type (no submit)', async ({ client, server, mcpBrowser }) => {
     const response = await client.callTool({
       name: 'browser_type',
       arguments: {
-        element: 'textbox',
-        ref: 'e2',
+        selectors: [{ ref: 'e2' }],
         text: 'Hi!',
       },
     });
@@ -170,8 +167,7 @@ async function setupAndTestBrowserTypeSubmit(
   const response = await client.callTool({
     name: 'browser_type',
     arguments: {
-      element: 'textbox',
-      ref: 'e2',
+      selectors: [{ ref: 'e2' }],
       text: inputText,
       submit: true,
       expectation: {

--- a/tests/wait.spec.ts
+++ b/tests/wait.spec.ts
@@ -28,8 +28,7 @@ test('browser_wait_for(text)', async ({ client, server }) => {
   await client.callTool({
     name: 'browser_click',
     arguments: {
-      element: 'Click me',
-      ref: 'e2',
+      selectors: [{ ref: 'e2' }],
     },
   });
 
@@ -57,8 +56,7 @@ test('browser_wait_for(textGone)', async ({ client, server }) => {
   await client.callTool({
     name: 'browser_click',
     arguments: {
-      element: 'Click me',
-      ref: 'e2',
+      selectors: [{ ref: 'e2' }],
     },
   });
 


### PR DESCRIPTION
Update all test cases to pass selectors as an array of objects, replacing the previous usage of element and ref fields in tool arguments. Also increase port spacing in fixtures to reduce server collision risk.