### PR TITLE
chore: migrate to npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,13 +15,11 @@ jobs:
           bun-version: latest
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: bun install
       - run: bunx playwright install --with-deps
       - run: bun run build:publish
       - run: bun run lint
       - run: bun run ctest
-      - run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish


### PR DESCRIPTION
## Summary
- Migrate from NPM_TOKEN to npm trusted publishing (OIDC)
- Update Node.js to v24 for npm 11.5.1+ requirement
- Remove --provenance flag (automatically included with trusted publishing)

## Background
npm trusted publishing uses OIDC for authentication, eliminating the need for long-lived tokens. This improves security by using short-lived, workflow-specific credentials.

## Test plan
- [ ] Verify next release publishes successfully via trusted publishing
- [ ] Remove `NPM_TOKEN` secret from repository after successful publish