### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tontoko/fast-playwright-mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Bump package.json version to 0.1.3 to match the release tag

## Background
The publish workflow failed because package.json was still at 0.1.2 while the release tag was 0.1.3.