### PR TITLE
fix(find-elements): resolve implicit ARIA roles via getByRole

### DIFF
--- a/src/diagnostics/element-discovery.ts
+++ b/src/diagnostics/element-discovery.ts
@@ -317,58 +317,44 @@ export class ElementDiscovery extends DiagnosticBase {
     const alternatives: AlternativeElement[] = [];
 
     try {
-      const elements = await page.$$(`[role="${role}"]`);
-
-      // Use reduce for sequential processing
-      const totalFound = await elements.reduce(
-        async (previousPromise, element) => {
-          const currentFound = await previousPromise;
-
-          if (currentFound >= maxResults) {
-            await this.safeDispose(
-              element,
-              `findByRole-excess-${currentFound}`
-            );
-            return currentFound;
-          }
-
-          try {
-            const confidence = 0.7; // Base confidence for role match
-
-            // Wrap element in smart handle
-            const smartElement = this.smartHandleBatch.add(element);
-
-            alternatives.push({
-              selector: await this.generateSelector(element),
-              confidence,
-              reason: `role match: "${role}"`,
-              element: smartElement,
-              elementId: `role_${currentFound}`,
-            });
-            return currentFound + 1;
-          } catch (elementError) {
-            elementDiscoveryDebug(
-              'Element role processing failed:',
-              elementError
-            );
-            await this.safeDispose(
-              element,
-              `findByRole-element-${currentFound}`
-            );
-            return currentFound;
-          }
-        },
-        Promise.resolve(0)
+      // Use Playwright's getByRole which resolves both explicit role="..."
+      // attributes and implicit ARIA roles per the WAI-ARIA spec (e.g. <h1> →
+      // heading, <button> → button, <a href> → link). Replaces a previous
+      // `[role="${role}"]` attribute lookup plus a hardcoded 5-role fallback
+      // mapping which silently missed most implicit roles (heading, paragraph,
+      // separator, generic, img, list, navigation, etc.).
+      const locator = page.getByRole(
+        role as Parameters<typeof page.getByRole>[0]
       );
+      const elements = await locator.elementHandles();
 
-      // Also find elements with implicit roles
-      if (totalFound < maxResults) {
-        const implicitRoleElements = await this.findImplicitRoleElements(
-          role,
-          maxResults - totalFound
-        );
-        alternatives.push(...implicitRoleElements);
-      }
+      await elements.reduce(async (previousPromise, element) => {
+        const currentFound = await previousPromise;
+
+        if (currentFound >= maxResults) {
+          await this.safeDispose(element, `findByRole-excess-${currentFound}`);
+          return currentFound;
+        }
+
+        try {
+          const smartElement = this.smartHandleBatch.add(element);
+          alternatives.push({
+            selector: await this.generateSelector(element),
+            confidence: 0.7,
+            reason: `role match: "${role}"`,
+            element: smartElement,
+            elementId: `role_${currentFound}`,
+          });
+          return currentFound + 1;
+        } catch (elementError) {
+          elementDiscoveryDebug(
+            'Element role processing failed:',
+            elementError
+          );
+          await this.safeDispose(element, `findByRole-element-${currentFound}`);
+          return currentFound;
+        }
+      }, Promise.resolve(0));
     } catch {
       // Role search failed - continue with next search strategy
     }
@@ -567,155 +553,6 @@ export class ElementDiscovery extends DiagnosticBase {
       await this.safeDispose(
         element,
         `findByAttributes-element-${currentFound}`
-      );
-      return false;
-    }
-  }
-
-  private async findImplicitRoleElements(
-    role: string,
-    maxResults: number
-  ): Promise<AlternativeElement[]> {
-    const roleTagMapping: Record<string, string[]> = {
-      button: ['button', 'input[type="button"]', 'input[type="submit"]'],
-      textbox: ['input[type="text"]', 'input[type="email"]', 'textarea'],
-      link: ['a[href]'],
-      checkbox: ['input[type="checkbox"]'],
-      radio: ['input[type="radio"]'],
-    };
-
-    const tags = roleTagMapping[role] ?? [];
-    const alternatives: AlternativeElement[] = [];
-
-    await this.processImplicitRoleTags(tags, role, alternatives, maxResults);
-    return alternatives;
-  }
-
-  private async processImplicitRoleTags(
-    tags: string[],
-    role: string,
-    alternatives: AlternativeElement[],
-    maxResults: number
-  ): Promise<void> {
-    let totalFound = 0;
-
-    const processTagsSequentially = async (index: number): Promise<void> => {
-      if (index >= tags.length || totalFound >= maxResults) {
-        return;
-      }
-
-      const tagSelector = tags[index];
-      totalFound = await this.processImplicitRoleTag(
-        tagSelector,
-        role,
-        alternatives,
-        totalFound,
-        maxResults
-      );
-
-      await processTagsSequentially(index + 1);
-    };
-
-    await processTagsSequentially(0);
-  }
-
-  private async processImplicitRoleTag(
-    tagSelector: string,
-    role: string,
-    alternatives: AlternativeElement[],
-    totalFound: number,
-    maxResults: number
-  ): Promise<number> {
-    const page = this.getPage();
-
-    try {
-      const elements = await page.$$(tagSelector);
-      return await this.processImplicitRoleElements(
-        elements,
-        tagSelector,
-        role,
-        alternatives,
-        totalFound,
-        maxResults
-      );
-    } catch {
-      // Implicit role search failed - continue processing
-      return totalFound;
-    }
-  }
-
-  private async processImplicitRoleElements(
-    elements: playwright.ElementHandle[],
-    tagSelector: string,
-    role: string,
-    alternatives: AlternativeElement[],
-    totalFound: number,
-    maxResults: number
-  ): Promise<number> {
-    let currentFound = totalFound;
-
-    const processElementsSequentially = async (
-      index: number
-    ): Promise<void> => {
-      if (index >= elements.length) {
-        return;
-      }
-
-      const element = elements[index];
-      if (currentFound >= maxResults) {
-        await this.safeDispose(
-          element,
-          `findImplicitRole-excess-${currentFound}`
-        );
-        return processElementsSequentially(index + 1);
-      }
-
-      const processResult = await this.processImplicitRoleElement(
-        element,
-        tagSelector,
-        role,
-        alternatives,
-        currentFound
-      );
-
-      if (processResult) {
-        currentFound++;
-      }
-
-      await processElementsSequentially(index + 1);
-    };
-
-    await processElementsSequentially(0);
-    return currentFound;
-  }
-
-  private async processImplicitRoleElement(
-    element: playwright.ElementHandle,
-    tagSelector: string,
-    role: string,
-    alternatives: AlternativeElement[],
-    currentFound: number
-  ): Promise<boolean> {
-    try {
-      const smartElement = this.smartHandleBatch.add(element);
-
-      alternatives.push({
-        selector: await this.generateSelector(element),
-        confidence: 0.6,
-        reason: `implicit role match: "${role}" via ${tagSelector}`,
-        element: smartElement,
-        elementId: `implicit_${currentFound}`,
-      });
-
-      return true;
-    } catch (elementError) {
-      elementDiscoveryDebug(
-        'Implicit role element processing failed:',
-        elementError
-      );
-      await this.safeDispose(
-        element,
-        `findImplicitRole-element-${currentFound}`
       );
       return false;
     }

--- a/tests/browser-find-elements.spec.ts
+++ b/tests/browser-find-elements.spec.ts
@@ -2,7 +2,7 @@
  * browser_find_elements Tool Tests
  */
 
-import { test } from './fixtures.js';
+import { expect, test } from './fixtures.js';
 import {
   expectFindElementsNoMatches,
   expectFindElementsSuccess,
@@ -82,4 +82,102 @@ test('browser_find_elements - limit results', async ({ client, server }) => {
   );
 
   expectFindElementsSuccess(result);
+});
+
+// Regression coverage for https://github.com/tontoko/fast-playwright-mcp/issues/27
+// Previously findByRole used `page.$$('[role="${role}"]')` which only matched
+// elements with an explicit role="" attribute, so <h1>, <p>, <hr>, a bare
+// <button>, and <a href> were all invisible to role-based search.
+test('browser_find_elements - role heading finds implicit h1/h2', async ({
+  client,
+  server,
+}) => {
+  const result = await setupFindElementsTest(
+    client,
+    server,
+    FIND_ELEMENTS_HTML_TEMPLATES.IMPLICIT_ROLE_ELEMENTS,
+    { role: 'heading' }
+  );
+
+  expectFindElementsSuccess(result);
+  expect(result.content[0].text).toContain('Found 2 elements');
+  expect(result.content[0].text).toContain('role match: "heading"');
+});
+
+test('browser_find_elements - role paragraph finds implicit p', async ({
+  client,
+  server,
+}) => {
+  const result = await setupFindElementsTest(
+    client,
+    server,
+    FIND_ELEMENTS_HTML_TEMPLATES.IMPLICIT_ROLE_ELEMENTS,
+    { role: 'paragraph' }
+  );
+
+  expectFindElementsSuccess(result);
+  expect(result.content[0].text).toContain('Found 2 elements');
+  expect(result.content[0].text).toContain('role match: "paragraph"');
+});
+
+test('browser_find_elements - role separator finds implicit hr', async ({
+  client,
+  server,
+}) => {
+  const result = await setupFindElementsTest(
+    client,
+    server,
+    FIND_ELEMENTS_HTML_TEMPLATES.IMPLICIT_ROLE_ELEMENTS,
+    { role: 'separator' }
+  );
+
+  expectFindElementsSuccess(result);
+  expect(result.content[0].text).toContain('Found 1 elements');
+  expect(result.content[0].text).toContain('role match: "separator"');
+});
+
+test('browser_find_elements - role button finds bare button and role=button div', async ({
+  client,
+  server,
+}) => {
+  const result = await setupFindElementsTest(
+    client,
+    server,
+    FIND_ELEMENTS_HTML_TEMPLATES.IMPLICIT_ROLE_ELEMENTS,
+    { role: 'button' }
+  );
+
+  expectFindElementsSuccess(result);
+  expect(result.content[0].text).toContain('Found 2 elements');
+  expect(result.content[0].text).toContain('role match: "button"');
+});
+
+test('browser_find_elements - role link finds implicit a[href]', async ({
+  client,
+  server,
+}) => {
+  const result = await setupFindElementsTest(
+    client,
+    server,
+    FIND_ELEMENTS_HTML_TEMPLATES.IMPLICIT_ROLE_ELEMENTS,
+    { role: 'link' }
+  );
+
+  expectFindElementsSuccess(result);
+  expect(result.content[0].text).toContain('Found 1 elements');
+  expect(result.content[0].text).toContain('role match: "link"');
+});
+
+test('browser_find_elements - unknown role returns no matches without throwing', async ({
+  client,
+  server,
+}) => {
+  const result = await setupFindElementsTest(
+    client,
+    server,
+    FIND_ELEMENTS_HTML_TEMPLATES.IMPLICIT_ROLE_ELEMENTS,
+    { role: 'not-a-real-role' }
+  );
+
+  expectFindElementsNoMatches(result);
 });

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -782,6 +782,18 @@ export const FIND_ELEMENTS_HTML_TEMPLATES = {
       { length: count },
       (_, i) => `<button>Button ${i}</button>`
     ).join('')}</div>`,
+  IMPLICIT_ROLE_ELEMENTS: `
+    <main>
+      <h1>Main title</h1>
+      <h2>Subtitle</h2>
+      <p>First paragraph.</p>
+      <p>Second paragraph.</p>
+      <hr>
+      <button>Bare button</button>
+      <div role="button">Explicit role button</div>
+      <a href="/somewhere">A link</a>
+    </main>
+  `,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

`browser_find_elements` with `searchCriteria.role` silently returned zero results for implicit ARIA roles (heading, paragraph, separator, generic, img, list, navigation, and any bare `<button>` / `<a href>` / `<input>` without an explicit `role=""` attribute).

Root cause was `ElementDiscovery.findByRole` in `src/diagnostics/element-discovery.ts`, which used `page.$$(\`[role="${role}"]\`)` — a CSS attribute selector that only matches explicit `role` attributes — plus a hardcoded 5-role fallback mapping (`button`, `textbox`, `link`, `checkbox`, `radio`). Everything else fell through the cracks.

Replaced with `page.getByRole(role).elementHandles()`, which resolves both explicit role attributes and implicit ARIA roles per the WAI-ARIA spec. Deleted the 5 dead helper methods that the hardcoded mapping relied on (net −135 LOC).

As a side benefit, `getByRole` doesn't string-interpolate into a CSS selector, so it also closes a minor injection surface the old attribute lookup had.

## Tests

Added 6 regression tests covering `heading`, `paragraph`, `separator`, `button` (bare + `role="button"` div), `link`, and an unknown-role no-match case. All 11 tests in `browser-find-elements.spec.ts` pass, plus the adjacent `batch-find-elements.spec.ts` and `element-discovery-selector.spec.ts` specs (32/32 green).

Fixes #27